### PR TITLE
Use ES named exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-function makeSubject() {
+export function makeSubject() {
   let sinks = [];
   return (type, data) => {
     if (type === 0) {
@@ -19,5 +19,3 @@ function makeSubject() {
     }
   }
 }
-
-module.exports = makeSubject;


### PR DESCRIPTION
This would have a few advantages and one disadvantage:
Pro:
- prevents users from misspelling the import in their code base
- allows IDEs to auto-import missing operators
- can make use of tree shaking (`callbag-basics` can reexport and thus allow a bundler to eliminated unneeded operators, same goes for other callbag operator collections)
- can make use of scope hoisting. Without ES modules the bundler has to wrap each package in an IIFE. This a) increases the bundle size and b) slows down initial execution. This problem gets worse the more packages have to be imported (with one operator per package this is a lot)

Con:
- Breaking change

I think this should be decided before callbags are used for bigger projects in the wild. (This PR is a placeholder for all your other operators, once decided they should be updated too)